### PR TITLE
* Add notation to the help function to display the pack function

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -344,6 +344,7 @@ void actionHelp()
     std::cout << "  --format, -f DAT file format" << std::endl;
     std::cout << "  --quiet, -q quite mode. Do not display anything" << std::endl;
     std::cout << "  --unpack, -u unpack DAT file" << std::endl;
+    std::cout << "  --pack, -p pack pack DAT file" << std::endl;
     std::cout << "  --source, -s path to DAT file" << std::endl;
     std::cout << "  --destination, -d path to extract files" << std::endl;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -344,7 +344,7 @@ void actionHelp()
     std::cout << "  --format, -f DAT file format" << std::endl;
     std::cout << "  --quiet, -q quite mode. Do not display anything" << std::endl;
     std::cout << "  --unpack, -u unpack DAT file" << std::endl;
-    std::cout << "  --pack, -p pack pack DAT file" << std::endl;
+    std::cout << "  --pack, -p pack DAT file" << std::endl;
     std::cout << "  --source, -s path to DAT file" << std::endl;
     std::cout << "  --destination, -d path to extract files" << std::endl;
 }


### PR DESCRIPTION
I know this is a tiny problem, but the pack option was not included in the help display.
